### PR TITLE
For #30564 - Connecting to perforce is now exclusive across threads.

### DIFF
--- a/hooks/shared/filter_publishes.py
+++ b/hooks/shared/filter_publishes.py
@@ -12,7 +12,7 @@ import os
 import sys
 
 import sgtk
-from sgtk import Hook
+from sgtk import Hook, TankError
 
 TK_FRAMEWORK_PERFORCE_NAME = "tk-framework-perforce_v0.x.x"
 

--- a/hooks/tk-multi-workfiles/filter_work_files.py
+++ b/hooks/tk-multi-workfiles/filter_work_files.py
@@ -12,7 +12,7 @@ import os
 from datetime import datetime
 
 import sgtk
-from sgtk import Hook
+from sgtk import Hook, TankError
 from tank_vendor.shotgun_api3 import sg_timezone
 
 TK_FRAMEWORK_PERFORCE_NAME = "tk-framework-perforce_v0.x.x"

--- a/info.yml
+++ b/info.yml
@@ -72,7 +72,10 @@ configuration:
         parameters: [depot_path, user, workspace, revision, p4]
         default_value: load_review_data
         description: ''
-        
+
+# This framework is shared so that there is only a single instance
+shared: True
+
 # the Shotgun fields that this engine needs in order to operate correctly
 requires_shotgun_fields:
 


### PR DESCRIPTION
- This ensures that the user is not presented with multiple password entry prompts when an app tries to connect from multiple threads at the same time.
- Also added a couple of missing imports to hooks.