### PR TITLE
33063 Add user activity metrics calls

### DIFF
--- a/info.yml
+++ b/info.yml
@@ -87,6 +87,3 @@ description: "Common Perforce functionality used by various apps & hooks"
 requires_shotgun_version:
 requires_core_version: "v0.14.61"
 
-# XXX will require core that supports metrics logging
- 
-        

--- a/info.yml
+++ b/info.yml
@@ -87,5 +87,6 @@ description: "Common Perforce functionality used by various apps & hooks"
 requires_shotgun_version:
 requires_core_version: "v0.14.61"
 
+# XXX will require core that supports metrics logging
  
         

--- a/python/connection/connection.py
+++ b/python/connection/connection.py
@@ -370,6 +370,7 @@ class ConnectionHandler(object):
                 except SgtkP4Error, e:
                     raise TankError("Perforce: Workspace '%s' is not valid! - %s" % (workspace, e))
 
+            self._fw.log_metric("Connected")
             return self._p4
 
         except TankError, e:

--- a/python/connection/connection.py
+++ b/python/connection/connection.py
@@ -370,7 +370,12 @@ class ConnectionHandler(object):
                 except SgtkP4Error, e:
                     raise TankError("Perforce: Workspace '%s' is not valid! - %s" % (workspace, e))
 
-            self._fw.log_metric("Connected")
+            try:
+                self._fw.log_metric("Connected")
+            except:
+                # ignore all errors. ex: using a core that doesn't support metrics
+                pass
+
             return self._p4
 
         except TankError, e:


### PR DESCRIPTION
The calls log the metrics internally and ignore any errors. This prevents the need to force the app/fw users to update to a new core that supports metrics. When a supported core is updated, the metrics will be logged.